### PR TITLE
Removed quotes from timestamp values

### DIFF
--- a/policies/NewRelicAPI.xml
+++ b/policies/NewRelicAPI.xml
@@ -29,7 +29,7 @@
                            "name": "@apiproxy.name#",
                            "parent.id": "@dt.incomingParentID#"
                          },
-                         "timestamp": "@dt.apigeeStartTime#"
+                         "timestamp": @dt.apigeeStartTime#
                        },
                        {
                          "trace.id": "@dt.traceID#",
@@ -40,7 +40,7 @@
                            "parent.id": "@dt.apigeeSpanID#",
                            "response.code": @message.status.code#
                          },
-                         "timestamp": "@dt.targetStart#"
+                         "timestamp": @dt.targetStart#
                        }
                        @dt.internalSpans#
                      ]


### PR DESCRIPTION
Having quotes around timestamp values in NewRelicAPI.xml was causing JSON processing errors on the spans resulting in the Apigee spans being dropped. Removing these quotes resolves the processing issue.